### PR TITLE
feat: allow disabling of yarn via YARN_ENABLED

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ GIT_UNPULLED="⇣"
 GIT_UNPUSHED="⇡"
 ```
 
+ENV variables to enable or disable yarn:
+
+```shell
+YARN_ENABLED=true
+```
+
 ### Read more / Credits
 
 * [Original iTerm2 issue for TouchBar support](https://gitlab.com/gnachman/iterm2/issues/5281)

--- a/zsh-iterm-touchbar.plugin.zsh
+++ b/zsh-iterm-touchbar.plugin.zsh
@@ -6,6 +6,9 @@ GIT_STASHED="${GIT_STASHED:-$}"
 GIT_UNPULLED="${GIT_UNPULLED:-⇣}"
 GIT_UNPUSHED="${GIT_UNPUSHED:-⇡}"
 
+# YARN
+YARN_ENABLED=true
+
 # Output name of current branch.
 git_current_branch() {
   local ref
@@ -143,7 +146,7 @@ function _displayDefault() {
   # PACKAGE.JSON
   # ------------
   if [[ -f package.json ]]; then
-      if [[ -f yarn.lock ]]; then
+      if [[ -f yarn.lock ]] && [[ "$YARN_ENABLED" = true ]]; then
           pecho "\033]1337;SetKeyLabel=F5=🐱 yarn-run\a"
           bindkey "${fnKeys[5]}" _displayYarnScripts
       else


### PR DESCRIPTION
This allows users to switch to npm even if a yarn.lock file is present.

---
Personally I prefer npm but our project has both a yarn.lock and package-lock.json file. I needed a way to disable yarn via a config setting.